### PR TITLE
fix(install): clean exit from install.sh (cleanup trap under set -u)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,9 @@ sha256_of() {
 }
 
 main() {
-  local target os arch tag asset base tmp sudo expected actual
+  # tmp is intentionally NOT local: the EXIT trap below runs in global scope and
+  # must still see it (otherwise `set -u` trips on cleanup after a successful run).
+  local target os arch tag asset base sudo expected actual
   target="${1:-$DEFAULT_TARGET}"
   os="$(detect_os)"
   arch="$(detect_arch)"
@@ -67,7 +69,7 @@ main() {
   info "Installing pzmod ${tag} (${os}/${arch}) to ${target}"
 
   tmp="$(mktemp -d)"
-  trap 'rm -rf "$tmp"' EXIT
+  trap 'rm -rf "${tmp:-}"' EXIT
 
   curl -fSL --proto '=https' --tlsv1.2 -o "$tmp/pzmod" "${base}/${asset}" \
     || err "no prebuilt binary for ${asset} in ${tag} (see ${base})"


### PR DESCRIPTION
## Fix install.sh clean exit (cleanup trap under `set -u`)

The v3.0.0 release published fine, but the `test-install` smoke tests went red.
Cause: `install.sh`'s `EXIT` trap (`rm -rf "$tmp"`) runs in global scope, while
`tmp` was declared `local` to `main()`. Under `set -u`, a **successful** install
then ended with `tmp: unbound variable` and exit 1 (binary installed correctly,
but the script reported failure and left the temp dir).

### Fix
- Make `tmp` a global so the trap can see it.
- Guard the trap with `${tmp:-}`.

### Verified
End-to-end in a `debian:12` container against the published v3.0.0 release:
download, checksum, install, cleanup, and `pzmod --version` / `pzmod help` all
exit 0. This also turns the release workflow's `test-install` jobs green for
future releases.

Note: only the install *script* (served from `main`) was affected; the v3.0.0
binaries and the container image are correct and need no re-release.
