### PR TITLE
fix(tui): navigation and refresh fixes for profiles and server info

### DIFF
--- a/internal/tui/firstrun_test.go
+++ b/internal/tui/firstrun_test.go
@@ -1,0 +1,98 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+	"github.com/kldzj/pzmod/internal/service"
+	"github.com/kldzj/pzmod/internal/steam"
+	"github.com/kldzj/pzmod/internal/steam/steamtest"
+	"github.com/kldzj/pzmod/internal/store"
+)
+
+// TestSettingsSaveReturnsToLauncher covers the first-run flow: with no API key
+// configured, the Settings screen is pushed on top of the launcher; after the
+// user saves a valid key it should pop back to the profile menu automatically,
+// without an extra esc.
+func TestSettingsSaveReturnsToLauncher(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	st, err := store.New(store.WithRoot(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A profile exists so the launcher shows its "enter: open" chrome; no API
+	// key -> the Settings prompt pops up first.
+	ini := filepath.Join(t.TempDir(), "server.ini")
+	if err := os.WriteFile(ini, []byte("Mods=\nWorkshopItems=\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.AddProfile(store.Profile{Name: "Demo Server", IniPath: ini, Build: "b41"}); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New(service.New(steamtest.New(), st), st, context.Background(), NewLauncher())
+	m.s.NewSteam = func(string) steam.API { return steamtest.New() }
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(100, 30))
+	tm.Send(tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	// First run: the Settings prompt is on top.
+	waitForText(t, tm, "Steam Web API key")
+
+	// Type a valid 32-char key and save.
+	for _, r := range "0123456789abcdef0123456789abcdef" {
+		tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// We should be back on the profile menu without pressing esc: "enter: open"
+	// is launcher-only chrome (Settings shows "enter: save").
+	waitForText(t, tm, "enter: open")
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+}
+
+// TestLauncherReloadsOnResume covers the add-profile refresh: a profile added
+// while a child screen was on top must appear when we return to the launcher.
+// The refresh must ride the reliable post-Pop resumedMsg, not a racy
+// profilesChangedMsg batched alongside Pop().
+func TestLauncherReloadsOnResume(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	st, err := store.New(store.WithRoot(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Session{Store: st, Theme: DefaultTheme()}
+	l := &launcher{}
+
+	// Initial load: no profiles yet.
+	msg := l.Init(s)()
+	l.Update(s, msg)
+	if len(l.profiles) != 0 {
+		t.Fatalf("expected 0 profiles initially, got %d", len(l.profiles))
+	}
+
+	// A profile is added while the add-profile screen sits on top.
+	ini := filepath.Join(t.TempDir(), "server.ini")
+	if err := os.WriteFile(ini, []byte("Mods=\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.AddProfile(store.Profile{Name: "Added", IniPath: ini, Build: "b41"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Returning to the launcher (Pop -> resumedMsg) must refresh the list.
+	_, cmd := l.Update(s, resumedMsg{})
+	if cmd == nil {
+		t.Fatal("launcher did not reload on resumedMsg")
+	}
+	l.Update(s, cmd())
+	if len(l.profiles) != 1 {
+		t.Fatalf("expected 1 profile after resume-refresh, got %d", len(l.profiles))
+	}
+}

--- a/internal/tui/launcher.go
+++ b/internal/tui/launcher.go
@@ -63,6 +63,10 @@ func (l *launcher) Update(s *Session, msg tea.Msg) (Screen, tea.Cmd) {
 		return l, nil
 	case profilesChangedMsg:
 		return l, l.load(s)
+	case resumedMsg:
+		// Returning from a pushed child (e.g. the add-profile form): reload so a
+		// newly added or removed profile shows up. Cheap and idempotent.
+		return l, l.load(s)
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "up", "k":

--- a/internal/tui/profileform.go
+++ b/internal/tui/profileform.go
@@ -105,7 +105,9 @@ func (pf *profileform) create(s *Session) tea.Cmd {
 	}); err != nil {
 		return tea.Batch(Fail(err), Pop())
 	}
-	return tea.Batch(Toast("profile added"), Pop(), func() tea.Msg { return profilesChangedMsg{} })
+	// The launcher reloads on the resumedMsg that Pop() delivers, so no explicit
+	// profilesChangedMsg is needed (and batching one here would race the Pop).
+	return tea.Batch(Toast("profile added"), Pop())
 }
 
 func (pf *profileform) View(s *Session) string {

--- a/internal/tui/serverinfo.go
+++ b/internal/tui/serverinfo.go
@@ -42,8 +42,11 @@ func (si *serverinfo) Init(s *Session) tea.Cmd {
 }
 
 func (si *serverinfo) Update(s *Session, msg tea.Msg) (Screen, tea.Cmd) {
+	// esc is "back": keep whatever the user edited (huh binds the fields live) and
+	// return, rather than discarding it. Unchanged fields are left untouched so
+	// merely opening this screen and backing out never fabricates unsaved changes.
 	if k, ok := msg.(tea.KeyMsg); ok && k.String() == "esc" {
-		return si, Pop()
+		return si, si.commit(s)
 	}
 	if si.form == nil {
 		return si, nil
@@ -54,17 +57,38 @@ func (si *serverinfo) Update(s *Session, msg tea.Msg) (Screen, tea.Cmd) {
 	}
 	switch si.form.State {
 	case huh.StateCompleted:
-		cfg := s.Cfg
-		cfg.SetName(si.name)
-		cfg.SetDescription(encodeLINE(si.desc))
-		cfg.SetPublic(si.public)
-		cfg.SetPassword(si.password)
-		cfg.SetMaxPlayers(si.slots)
-		return si, tea.Batch(Toast("server info updated (unsaved)"), Pop())
+		return si, si.commit(s)
 	case huh.StateAborted:
 		return si, Pop()
 	}
 	return si, cmd
+}
+
+// commit writes back any fields that actually changed and returns the command to
+// leave the screen (with a toast only when something was applied). Comparing
+// against the current values keeps an untouched exit from marking the config
+// dirty, since the setter re-renders lines and can differ from the on-disk bytes.
+func (si *serverinfo) commit(s *Session) tea.Cmd {
+	cfg := s.Cfg
+	changed := false
+	set := func(cur, next string, apply func(string)) {
+		if next != cur {
+			apply(next)
+			changed = true
+		}
+	}
+	set(cfg.Name(), si.name, cfg.SetName)
+	set(cfg.Description(), encodeLINE(si.desc), cfg.SetDescription)
+	set(cfg.Password(), si.password, cfg.SetPassword)
+	set(cfg.MaxPlayers(), si.slots, cfg.SetMaxPlayers)
+	if si.public != cfg.Public() {
+		cfg.SetPublic(si.public)
+		changed = true
+	}
+	if changed {
+		return tea.Batch(Toast("server info updated (unsaved)"), Pop())
+	}
+	return Pop()
 }
 
 func (si *serverinfo) View(s *Session) string {

--- a/internal/tui/serverinfo_test.go
+++ b/internal/tui/serverinfo_test.go
@@ -1,0 +1,52 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/kldzj/pzmod/internal/serverconfig"
+)
+
+func newServerInfo(t *testing.T, body string) (*Session, *serverinfo) {
+	t.Helper()
+	cfg := serverconfig.FromBytes("server.ini", []byte(body))
+	s := &Session{Cfg: cfg, Theme: DefaultTheme(), Width: 80, Height: 24}
+	si := &serverinfo{}
+	si.Init(s) // seeds the bound fields and builds the form
+	return s, si
+}
+
+// TestServerInfoAppliesEditsOnEsc: editing a field then pressing esc ("back")
+// must keep the change in the in-memory config, not discard it. huh writes the
+// bound variable on every keystroke, so setting si.name mimics a real edit.
+func TestServerInfoAppliesEditsOnEsc(t *testing.T) {
+	s, si := newServerInfo(t, "PublicName=Old Name\nMods=\n")
+	if si.name != "Old Name" {
+		t.Fatalf("Init did not seed name: %q", si.name)
+	}
+	si.name = "New Name" // user typed a new name
+
+	_, cmd := si.Update(s, tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd == nil {
+		t.Fatal("esc after an edit should apply + pop (non-nil cmd)")
+	}
+	if got := s.Cfg.Name(); got != "New Name" {
+		t.Fatalf("name not applied on esc: got %q want %q", got, "New Name")
+	}
+	if !s.Cfg.HasUnsavedChanges() {
+		t.Fatal("edited config should be dirty after esc")
+	}
+}
+
+// TestServerInfoEscWithoutEditsStaysClean: opening the editor and backing out
+// without touching anything must not fabricate unsaved changes, even when the
+// original line has spaces around '=' that the setter would re-render away.
+func TestServerInfoEscWithoutEditsStaysClean(t *testing.T) {
+	s, si := newServerInfo(t, "PublicName = Old Name\nMods=\n")
+	if _, cmd := si.Update(s, tea.KeyMsg{Type: tea.KeyEsc}); cmd == nil {
+		t.Fatal("esc should still pop (non-nil cmd)")
+	}
+	if s.Cfg.HasUnsavedChanges() {
+		t.Fatal("esc without edits must not mark the config dirty")
+	}
+}

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -93,10 +93,9 @@ func (st *settings) save(s *Session) tea.Cmd {
 	}
 	// Rebuild the service layer so subsequent Steam calls use the new key.
 	s.Svc = service.New(steam.New(key), s.Store)
-	st.hasKey = true
-	st.input.SetValue("")
-	st.status, st.statusErr = "API key saved", false
-	return nil
+	// Return to the previous screen (the profile menu on first run, the dashboard
+	// from the settings jump) and confirm via a toast, since this screen goes away.
+	return tea.Batch(Toast("API key saved"), Pop())
 }
 
 func (st *settings) View(s *Session) string {


### PR DESCRIPTION
## Summary

Fixes three TUI UX issues noticed when testing a fresh v2→v3 upgrade.

### 1. First-run API key doesn't return to the profile menu
On first run with no key configured, the Settings screen is pushed on top of the
launcher. `settings.save()` set an inline status and returned `nil` — it never
popped — so after saving you were stuck on the key form until you pressed `esc`.
Now a successful save toasts and pops back to the previous screen (profile menu
on first run, dashboard from the `,` jump).

### 2. Profile list doesn't reload after adding a profile
`profileform.create()` refreshed the launcher by emitting `profilesChangedMsg`
in the same `tea.Batch` as `Pop()`. Batch results arrive in nondeterministic
order and that message is delivered to the *active* screen, which was usually
still the (dismissing) form — so it was dropped and the list stayed stale. The
launcher now reloads on the reliable post-`Pop` `resumedMsg` (matching the
existing `installed`/`validate` screens), and the racy emit is removed.

### 3. Server info discards edits when you press "back"
The editor applied edits only when the `huh` form reached `StateCompleted`
(i.e. submitted from the last field). Pressing `esc` popped without applying, so
edits were silently lost. `esc` and submit now share a `commit()` that writes
back only the fields that actually changed — keeping edits as in-memory unsaved
changes without fabricating a phantom dirty state on an untouched exit.

## Testing
- `internal/tui/firstrun_test.go` — first-run save returns to the launcher; launcher reloads on resume.
- `internal/tui/serverinfo_test.go` — edits kept on esc; untouched exit stays clean.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.