### PR TITLE
fix(deps): bump ulikunitz/xz to v0.5.15 to restore 32-bit builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/ulikunitz/xz v0.5.14 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/xanzy/go-gitlab v0.83.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/crypto v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/ulikunitz/xz v0.5.14 h1:uv/0Bq533iFdnMHZdRBTOlaNMdb1+ZxXIlHDZHIHcvg=
-github.com/ulikunitz/xz v0.5.14/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=


### PR DESCRIPTION
## Summary

The `v3.0.1` release build failed compiling for 32-bit targets:

    build failed: exit status 1: # github.com/ulikunitz/xz/lzma
    .../ulikunitz/xz@v0.5.14/lzma/reader.go:33:15: cannot use 1 << 31 (untyped
    int constant 2147483648) as int value in assignment (overflows)
    target=linux_386_sse2

`ulikunitz/xz` is an indirect dependency via `creativeprojects/go-selfupdate`
(used by `internal/version`'s self-update check). #32 bumped it v0.5.11 → v0.5.14,
and v0.5.14 introduced a `1 << 31` overflow that breaks `GOARCH=386`. goreleaser
builds 386 by default (v3.0.0 shipped `pzmod_linux_i386` and `pzmod_windows_i386`),
so the release job died there. v0.5.15 fixes the overflow — keeping 32-bit build
parity with v3.0.0 rather than dropping those targets.

## Testing
- `GOOS=linux GOARCH=386 go build ./...` and `GOOS=windows GOARCH=386 go build ./...` now succeed.
- `go test ./...` passes.