### PR TITLE
feat(cli): headless/CI commands (mods show, --dry-run, doctor, completions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ pzmod set name "My Server"
 pzmod get list
 pzmod search hydrocraft
 pzmod mods add 2392709985 --resolve-deps
+pzmod mods show 2392709985 # print resolved details without adding
+pzmod mods add 2392709985 --dry-run # preview what would be added, write nothing
 pzmod validate              # exits non-zero on errors (CI-friendly)
+pzmod doctor # one-shot health check (key, config, build, validation)
 pzmod backup list
 
 # Add --json to any command for machine-readable output
@@ -114,6 +117,23 @@ Run `pzmod --help` for the full command list.
 With `--json`, any command prints its result as JSON on stdout; errors print
 as `{"error":"..."}` to stderr and the exit code is preserved, so scripts can
 read stdout and gate on the exit code.
+
+## Shell completions
+
+pzmod ships completions for bash, zsh, fish, and PowerShell. Print the script for
+your shell and source it (see `pzmod completion <shell> --help` for install paths):
+
+```bash
+# bash (current shell)
+source <(pzmod completion bash)
+
+# zsh (add to a dir on $fpath, then restart the shell)
+pzmod completion zsh > "${fpath[1]}/_pzmod"
+```
+
+Completions are context-aware: `--profile` completes your profile names,
+`mods remove`/`mods show` complete installed IDs, and `get`/`set` complete the
+known config keys.
 
 ## Requirements
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -163,4 +164,170 @@ func contains(s []string, v string) bool {
 		}
 	}
 	return false
+}
+
+func TestModsAddDryRunDoesNotWrite(t *testing.T) {
+	st := testStore(t)
+	_ = st.SetGlobalKey("0123456789abcdef0123456789abcdef")
+	useFakeSteam(t, cannedFake())
+	const original = "WorkshopItems=\nMods=\n"
+	ini := writeINI(t, original)
+
+	out, err := run(t, st, "mods", "add", "200", "--resolve-deps", "--dry-run", "--file", ini, "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got resolveJSON
+	if uerr := json.Unmarshal([]byte(out), &got); uerr != nil {
+		t.Fatalf("unmarshal %q: %v", out, uerr)
+	}
+	if !got.DryRun {
+		t.Errorf("dryRun = false; want true")
+	}
+	if !contains(got.AddWorkshopItems, "100") || !contains(got.AddWorkshopItems, "200") {
+		t.Errorf("addWorkshopItems = %v; want 100 and 200", got.AddWorkshopItems)
+	}
+	data, _ := os.ReadFile(ini)
+	if string(data) != original {
+		t.Errorf("file changed under --dry-run: %q", data)
+	}
+}
+
+func TestSetDryRunDoesNotWrite(t *testing.T) {
+	st := testStore(t)
+	ini := writeINI(t, "PublicName=old\nMaxPlayers=16\n")
+
+	out, err := run(t, st, "set", "name", "new", "--dry-run", "--file", ini, "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got setPreviewJSON
+	if uerr := json.Unmarshal([]byte(out), &got); uerr != nil {
+		t.Fatalf("unmarshal %q: %v", out, uerr)
+	}
+	if got.Old != "old" || got.New != "new" || !got.DryRun {
+		t.Errorf("preview = %+v", got)
+	}
+	data, _ := os.ReadFile(ini)
+	if string(data) != "PublicName=old\nMaxPlayers=16\n" {
+		t.Errorf("file changed under --dry-run: %q", data)
+	}
+}
+
+func TestDoctorClean(t *testing.T) {
+	st := testStore(t)
+	_ = st.SetGlobalKey("0123456789abcdef0123456789abcdef")
+	useFakeSteam(t, cannedFake())
+	// 100 is installed with its mod id; no missing deps -> clean.
+	ini := writeINI(t, "WorkshopItems=100\nMods=CoreLib\n")
+
+	out, err := run(t, st, "doctor", "--file", ini, "--json")
+	if err != nil {
+		t.Fatalf("doctor should pass on a clean config; err=%v out=%q", err, out)
+	}
+	var got doctorJSON
+	if uerr := json.Unmarshal([]byte(out), &got); uerr != nil {
+		t.Fatalf("unmarshal %q: %v", out, uerr)
+	}
+	if !got.OK {
+		t.Errorf("ok = false; want true. checks=%+v", got.Checks)
+	}
+}
+
+func TestDoctorValidationError(t *testing.T) {
+	st := testStore(t)
+	_ = st.SetGlobalKey("0123456789abcdef0123456789abcdef")
+	useFakeSteam(t, cannedFake())
+	// 200 requires 100, which is not installed -> validation error.
+	ini := writeINI(t, "WorkshopItems=200\nMods=Weapons\n")
+
+	out, err := run(t, st, "doctor", "--file", ini, "--json")
+	if err == nil {
+		t.Errorf("doctor should exit non-zero on a validation error; out=%q", out)
+	}
+	var got doctorJSON
+	if uerr := json.Unmarshal([]byte(out), &got); uerr != nil {
+		t.Fatalf("unmarshal %q: %v", out, uerr)
+	}
+	if got.OK {
+		t.Errorf("ok = true; want false")
+	}
+}
+
+func TestDoctorOfflineSkipsValidation(t *testing.T) {
+	st := testStore(t)
+	_ = st.SetGlobalKey("0123456789abcdef0123456789abcdef")
+	useFakeSteam(t, cannedFake())
+	ini := writeINI(t, "WorkshopItems=200\nMods=Weapons\n")
+
+	out, err := run(t, st, "doctor", "--file", ini, "--offline", "--json")
+	if err != nil {
+		t.Errorf("offline doctor should not fail on validation; err=%v", err)
+	}
+	if !strings.Contains(out, "\"validation\"") || !strings.Contains(out, "\"skip\"") {
+		t.Errorf("expected validation skip in %q", out)
+	}
+}
+
+func TestDoctorBadFile(t *testing.T) {
+	st := testStore(t)
+	out, err := run(t, st, "doctor", "--file", "/no/such/server.ini", "--json")
+	if err == nil {
+		t.Errorf("doctor should exit non-zero when the config cannot load; out=%q", out)
+	}
+}
+
+func TestModsRemoveDryRunDoesNotWrite(t *testing.T) {
+	st := testStore(t)
+	ini := writeINI(t, "WorkshopItems=100;200\nMods=CoreLib;Weapons\n")
+
+	out, err := run(t, st, "mods", "remove", "100", "CoreLib", "--dry-run", "--file", ini, "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got removePreviewJSON
+	if uerr := json.Unmarshal([]byte(out), &got); uerr != nil {
+		t.Fatalf("unmarshal %q: %v", out, uerr)
+	}
+	if !got.DryRun || !contains(got.RemovedItems, "100") || !contains(got.RemovedMods, "CoreLib") {
+		t.Errorf("preview = %+v", got)
+	}
+	data, _ := os.ReadFile(ini)
+	if string(data) != "WorkshopItems=100;200\nMods=CoreLib;Weapons\n" {
+		t.Errorf("file changed under --dry-run: %q", data)
+	}
+}
+
+func TestCompleteProfiles(t *testing.T) {
+	st := testStore(t)
+	ini := writeINI(t, "PublicName=x\n")
+	if _, err := run(t, st, "profile", "add", "--name", "Alpha", "--file", ini); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := completeProfiles(st)(nil, nil, "")
+	if !contains(got, "alpha") {
+		t.Errorf("profiles completion = %v; want alpha", got)
+	}
+}
+
+func TestCompleteInstalledIDs(t *testing.T) {
+	st := testStore(t)
+	ini := writeINI(t, "WorkshopItems=100;200\nMods=CoreLib\nMap=Springfield\n")
+	cmd := newModsRemoveCmd(st)
+	if err := cmd.Flags().Set("file", ini); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := cmd.ValidArgsFunction(cmd, nil, "")
+	for _, want := range []string{"100", "200", "CoreLib", "Springfield"} {
+		if !contains(got, want) {
+			t.Errorf("installed completion missing %q in %v", want, got)
+		}
+	}
+}
+
+func TestCompleteConfigKeys(t *testing.T) {
+	got, _ := completeConfigKeys(nil, nil, "")
+	if !contains(got, "name") {
+		t.Errorf("config keys completion = %v; want name", got)
+	}
 }

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"github.com/kldzj/pzmod/pkg/domain"
+	"github.com/kldzj/pzmod/pkg/store"
+	"github.com/spf13/cobra"
+)
+
+// completeProfiles suggests stored profile IDs. Read-only; degrades to no
+// suggestions on any error.
+func completeProfiles(st *store.Store) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		profs, err := st.Profiles()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		ids := make([]string, 0, len(profs))
+		for _, p := range profs {
+			ids = append(ids, p.ID)
+		}
+		return ids, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// completeInstalledIDs suggests the workshop IDs, logical mod IDs, and map names
+// from the resolved target config. No network. Degrades to nothing on error.
+func completeInstalledIDs(st *store.Store) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		t, err := resolveTarget(cmd, st)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		cfg, err := t.config()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		sm := cfg.ServerMods()
+		out := make([]string, 0, len(sm.WorkshopItems)+len(sm.Mods)+len(sm.Maps))
+		out = append(out, sm.WorkshopItems...)
+		for _, m := range sm.Mods {
+			out = append(out, domain.ParseModRef(m).ID)
+		}
+		out = append(out, sm.Maps...)
+		return out, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// completeConfigKeys suggests the known config alias keys, for the key argument
+// of get/set (only at the first positional position).
+func completeConfigKeys(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return sortedAliases(), cobra.ShellCompDirectiveNoFileComp
+}
+
+// registerFlagCompletions walks the command tree and registers profile-ID
+// completion for every command that has a --profile flag.
+func registerFlagCompletions(root *cobra.Command, st *store.Store) {
+	var walk func(c *cobra.Command)
+	walk = func(c *cobra.Command) {
+		if c.Flags().Lookup("profile") != nil {
+			_ = c.RegisterFlagCompletionFunc("profile", completeProfiles(st))
+		}
+		for _, sub := range c.Commands() {
+			walk(sub)
+		}
+	}
+	walk(root)
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/kldzj/pzmod/pkg/build"
+	"github.com/kldzj/pzmod/pkg/domain"
+	"github.com/kldzj/pzmod/pkg/store"
+	"github.com/spf13/cobra"
+)
+
+func newDoctorCmd(st *store.Store) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "doctor",
+		Short:         "Run health checks on the target config (exits non-zero on errors)",
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var checks []doctorCheckJSON
+
+			t, err := resolveTarget(cmd, st)
+			if err != nil {
+				checks = append(checks, doctorCheckJSON{Name: "target", Status: "error", Detail: err.Error()})
+				return finishDoctor(cmd, checks)
+			}
+
+			if st.HasAPIKey(t.profileID()) {
+				checks = append(checks, doctorCheckJSON{Name: "api-key", Status: "ok", Detail: "Steam API key configured"})
+			} else {
+				checks = append(checks, doctorCheckJSON{Name: "api-key", Status: "warn", Detail: "no Steam API key; run `pzmod api-key <key>` (validation skipped)"})
+			}
+
+			cfg, cerr := t.config()
+			if cerr != nil {
+				checks = append(checks, doctorCheckJSON{Name: "config", Status: "error", Detail: cerr.Error()})
+				return finishDoctor(cmd, checks)
+			}
+			sm := cfg.ServerMods()
+			checks = append(checks, doctorCheckJSON{
+				Name:   "config",
+				Status: "ok",
+				Detail: fmt.Sprintf("%s: %d mod(s), %d item(s), %d map(s)", t.iniPath(), len(sm.Mods), len(sm.WorkshopItems), len(sm.Maps)),
+			})
+
+			b := t.build()
+			if b == build.Unknown {
+				checks = append(checks, doctorCheckJSON{Name: "build", Status: "warn", Detail: "no build declared (b41/b42); compatibility checks limited"})
+			} else {
+				checks = append(checks, doctorCheckJSON{Name: "build", Status: "ok", Detail: b.Label()})
+			}
+
+			offline, _ := cmd.Flags().GetBool("offline")
+			switch {
+			case offline:
+				checks = append(checks, doctorCheckJSON{Name: "validation", Status: "skip", Detail: "--offline"})
+			case !st.HasAPIKey(t.profileID()):
+				checks = append(checks, doctorCheckJSON{Name: "validation", Status: "skip", Detail: "no API key"})
+			default:
+				report, verr := t.services(st).Validate(cmd.Context(), sm, b)
+				switch {
+				case verr != nil:
+					checks = append(checks, doctorCheckJSON{Name: "validation", Status: "error", Detail: verr.Error()})
+				case report.HasErrors():
+					checks = append(checks, doctorCheckJSON{
+						Name:   "validation",
+						Status: "error",
+						Detail: fmt.Sprintf("%d error(s), %d warning(s); run `pzmod validate` for detail", report.Count(domain.SeverityError), report.Count(domain.SeverityWarning)),
+					})
+				default:
+					checks = append(checks, doctorCheckJSON{
+						Name:   "validation",
+						Status: "ok",
+						Detail: fmt.Sprintf("%d warning(s), %d info", report.Count(domain.SeverityWarning), report.Count(domain.SeverityInfo)),
+					})
+				}
+			}
+
+			return finishDoctor(cmd, checks)
+		},
+	}
+	cmd.Flags().Bool("offline", false, "skip checks that need the Steam API")
+	addTargetFlags(cmd)
+	return cmd
+}
+
+// finishDoctor renders the checks (JSON or text) and returns a non-nil error
+// when any check failed, so the process exits non-zero.
+func finishDoctor(cmd *cobra.Command, checks []doctorCheckJSON) error {
+	hasError := false
+	for _, c := range checks {
+		if c.Status == "error" {
+			hasError = true
+		}
+	}
+	if jsonEnabled(cmd) {
+		if err := emitJSON(cmd, doctorJSON{Checks: checks, OK: !hasError}); err != nil {
+			return err
+		}
+	} else {
+		for _, c := range checks {
+			cmd.Printf("%s %s  %s\n", doctorTag(c.Status), c.Name, styleMuted.Render(c.Detail))
+		}
+		if hasError {
+			cmd.Println(styleError.Render("PROBLEMS") + " one or more checks failed")
+		} else {
+			cmd.Println(styleOK.Render("OK") + " all checks passed")
+		}
+	}
+	if hasError {
+		return fmt.Errorf("doctor found problems")
+	}
+	return nil
+}
+
+func doctorTag(status string) string {
+	switch status {
+	case "ok":
+		return styleOK.Render("OK  ")
+	case "warn":
+		return styleWarn.Render("WARN")
+	case "error":
+		return styleError.Render("ERR ")
+	default:
+		return styleMuted.Render("SKIP")
+	}
+}

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -59,6 +59,7 @@ func newGetCmd(st *store.Store) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.ValidArgsFunction = completeConfigKeys
 	addTargetFlags(cmd)
 	return cmd
 }

--- a/internal/cli/json_test.go
+++ b/internal/cli/json_test.go
@@ -176,3 +176,46 @@ func TestGetJSON(t *testing.T) {
 		t.Errorf("get = %+v", got)
 	}
 }
+
+func TestModsShowJSON(t *testing.T) {
+	st := testStore(t)
+	_ = st.SetGlobalKey("0123456789abcdef0123456789abcdef")
+	useFakeSteam(t, cannedFake())
+
+	out, err := run(t, st, "mods", "show", "200", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got modShowResultJSON
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", out, err)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("items = %+v", got.Items)
+	}
+	it := got.Items[0]
+	if it.ID != "200" || it.Title != "Weapons" || it.Type != "mod" {
+		t.Errorf("item = %+v", it)
+	}
+	if !contains(it.ModIDs, "Weapons") {
+		t.Errorf("modIds = %v", it.ModIDs)
+	}
+}
+
+func TestModsShowMissing(t *testing.T) {
+	st := testStore(t)
+	_ = st.SetGlobalKey("0123456789abcdef0123456789abcdef")
+	useFakeSteam(t, cannedFake())
+
+	out, err := run(t, st, "mods", "show", "999", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got modShowResultJSON
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", out, err)
+	}
+	if !contains(got.Missing, "999") {
+		t.Errorf("missing = %v; want it to contain 999", got.Missing)
+	}
+}

--- a/internal/cli/jsondto.go
+++ b/internal/cli/jsondto.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"github.com/kldzj/pzmod/pkg/service"
+	"github.com/kldzj/pzmod/pkg/steam"
 	"github.com/kldzj/pzmod/pkg/store"
 )
 
@@ -81,6 +82,7 @@ type multiModJSON struct {
 // resolveJSON is the shape of `mods add --resolve-deps --json`.
 type resolveJSON struct {
 	Resolved         bool           `json:"resolved"`
+	DryRun           bool           `json:"dryRun"`
 	AddWorkshopItems []string       `json:"addWorkshopItems"`
 	AddMods          []string       `json:"addMods"`
 	AddMaps          []string       `json:"addMaps"`
@@ -114,4 +116,72 @@ func newResolveJSON(plan service.ResolvePlan) resolveJSON {
 type shallowAddJSON struct {
 	Added   []string `json:"added"`
 	Missing []string `json:"missing"`
+	DryRun  bool     `json:"dryRun"`
+}
+
+// modShowJSON is one item in `mods show --json`. Field names are our own, not
+// the Steam API's, matching the searchItemJSON precedent.
+type modShowJSON struct {
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Type        string   `json:"type"` // "mod" | "collection"
+	FileSize    int64    `json:"fileSize"`
+	ModIDs      []string `json:"modIds"`
+	MapFolders  []string `json:"mapFolders"`
+	ChildIDs    []string `json:"childIds"`
+	Description string   `json:"description"`
+}
+
+// modShowResultJSON is the shape of `mods show --json`.
+type modShowResultJSON struct {
+	Items   []modShowJSON `json:"items"`
+	Missing []string      `json:"missing"`
+}
+
+// newModShowJSON builds a modShowJSON from a fetched Workshop item.
+func newModShowJSON(it *steam.WorkshopItem) modShowJSON {
+	parsed := it.Parse()
+	typ := "mod"
+	if it.IsCollection() {
+		typ = "collection"
+	}
+	return modShowJSON{
+		ID:          it.PublishedFileID,
+		Title:       it.Title,
+		Type:        typ,
+		FileSize:    int64(it.FileSize),
+		ModIDs:      orEmpty(parsed.Mods),
+		MapFolders:  orEmpty(parsed.Maps),
+		ChildIDs:    orEmpty(it.GetChildIDs()),
+		Description: it.Description,
+	}
+}
+
+// setPreviewJSON is the shape of `set --dry-run --json`.
+type setPreviewJSON struct {
+	Key    string `json:"key"`
+	Old    string `json:"old"`
+	New    string `json:"new"`
+	DryRun bool   `json:"dryRun"`
+}
+
+// removePreviewJSON is the shape of `mods remove --dry-run --json`.
+type removePreviewJSON struct {
+	RemovedMods  []string `json:"removedMods"`
+	RemovedItems []string `json:"removedItems"`
+	RemovedMaps  []string `json:"removedMaps"`
+	DryRun       bool     `json:"dryRun"`
+}
+
+// doctorCheckJSON is one health check in `doctor --json`.
+type doctorCheckJSON struct {
+	Name   string `json:"name"`
+	Status string `json:"status"` // ok | warn | error | skip
+	Detail string `json:"detail,omitempty"`
+}
+
+// doctorJSON is the shape of `doctor --json`.
+type doctorJSON struct {
+	Checks []doctorCheckJSON `json:"checks"`
+	OK     bool              `json:"ok"`
 }

--- a/internal/cli/mods.go
+++ b/internal/cli/mods.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dustin/go-humanize"
 	"github.com/kldzj/pzmod/pkg/build"
 	"github.com/kldzj/pzmod/pkg/domain"
 	"github.com/kldzj/pzmod/pkg/service"
@@ -18,7 +19,7 @@ func newModsCmd(st *store.Store) *cobra.Command {
 		Use:   "mods",
 		Short: "List, add, and remove mods",
 	}
-	cmd.AddCommand(newModsListCmd(st), newModsAddCmd(st), newModsRemoveCmd(st))
+	cmd.AddCommand(newModsListCmd(st), newModsAddCmd(st), newModsRemoveCmd(st), newModsShowCmd(st))
 	return cmd
 }
 
@@ -83,6 +84,7 @@ func newModsAddCmd(st *store.Store) *cobra.Command {
 			sm := cfg.ServerMods()
 
 			asJSON := jsonEnabled(cmd)
+			dryRun, _ := cmd.Flags().GetBool("dry-run")
 			resolveDeps, _ := cmd.Flags().GetBool("resolve-deps")
 			var projected domain.ServerMods
 			var result any // JSON payload for the chosen path
@@ -93,7 +95,9 @@ func newModsAddCmd(st *store.Store) *cobra.Command {
 				}
 				projected = plan.Apply(sm, t.build() == build.B42)
 				if asJSON {
-					result = newResolveJSON(plan)
+					rj := newResolveJSON(plan)
+					rj.DryRun = dryRun
+					result = rj
 				} else {
 					printPlan(cmd, plan)
 				}
@@ -108,13 +112,25 @@ func newModsAddCmd(st *store.Store) *cobra.Command {
 					for i, it := range added {
 						addedIDs[i] = it.PublishedFileID
 					}
-					result = shallowAddJSON{Added: addedIDs, Missing: orEmpty(missing)}
+					result = shallowAddJSON{Added: addedIDs, Missing: orEmpty(missing), DryRun: dryRun}
 				} else {
-					cmd.Printf("added %d item(s)\n", len(added))
+					verb := "added"
+					if dryRun {
+						verb = "would add"
+					}
+					cmd.Printf("%s %d item(s)\n", verb, len(added))
 					if len(missing) > 0 {
 						cmd.Println(styleWarn.Render("could not fetch:"), strings.Join(missing, ", "))
 					}
 				}
+			}
+
+			if dryRun {
+				if asJSON {
+					return emitJSON(cmd, result)
+				}
+				cmd.Println(styleMuted.Render("dry run: nothing written"))
+				return nil
 			}
 
 			cfg.ApplyServerMods(projected)
@@ -134,6 +150,7 @@ func newModsAddCmd(st *store.Store) *cobra.Command {
 	}
 	cmd.Flags().Bool("resolve-deps", false, "also add transitive dependencies")
 	cmd.Flags().Bool("no-backup", false, "do not snapshot before saving")
+	cmd.Flags().Bool("dry-run", false, "resolve and show the plan without writing")
 	addTargetFlags(cmd)
 	return cmd
 }
@@ -152,11 +169,28 @@ func newModsRemoveCmd(st *store.Store) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sm := cfg.ServerMods()
+			before := cfg.ServerMods().Clone()
+			after := before
 			for _, id := range args {
-				sm = sm.RemoveItem(id).RemoveMod(id).RemoveMap(id)
+				after = after.RemoveItem(id).RemoveMod(id).RemoveMap(id)
 			}
-			cfg.ApplyServerMods(sm)
+
+			if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
+				prev := removePreviewJSON{
+					RemovedMods:  orEmpty(removedFrom(before.Mods, after.Mods)),
+					RemovedItems: orEmpty(removedFrom(before.WorkshopItems, after.WorkshopItems)),
+					RemovedMaps:  orEmpty(removedFrom(before.Maps, after.Maps)),
+					DryRun:       true,
+				}
+				if jsonEnabled(cmd) {
+					return emitJSON(cmd, prev)
+				}
+				cmd.Printf("would remove %d mod(s), %d item(s), %d map(s) (dry run, nothing written)\n",
+					len(prev.RemovedMods), len(prev.RemovedItems), len(prev.RemovedMaps))
+				return nil
+			}
+
+			cfg.ApplyServerMods(after)
 			if noBackup, _ := cmd.Flags().GetBool("no-backup"); !noBackup {
 				if _, err := t.services(st).SnapshotProfile(t.profile, "before mods remove", "auto"); err != nil {
 					return err
@@ -172,6 +206,8 @@ func newModsRemoveCmd(st *store.Store) *cobra.Command {
 		},
 	}
 	cmd.Flags().Bool("no-backup", false, "do not snapshot before saving")
+	cmd.Flags().Bool("dry-run", false, "show what would be removed without writing")
+	cmd.ValidArgsFunction = completeInstalledIDs(st)
 	addTargetFlags(cmd)
 	return cmd
 }
@@ -228,4 +264,83 @@ func printPlan(cmd *cobra.Command, plan service.ResolvePlan) {
 	if len(plan.Cycles) > 0 {
 		cmd.Println(styleWarn.Render(fmt.Sprintf("%d dependency cycle(s) detected", len(plan.Cycles))))
 	}
+}
+
+func newModsShowCmd(st *store.Store) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <id...>",
+		Short: "Show resolved Workshop details for one or more items",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			profile, _ := cmd.Flags().GetString("profile")
+			if !st.HasAPIKey(profile) {
+				return errNoKey
+			}
+			key, _ := st.APIKey(profile)
+			svc := service.New(steamFactory(key), st)
+
+			items, missing, err := svc.Details(cmd.Context(), args)
+			if err != nil {
+				return err
+			}
+			if jsonEnabled(cmd) {
+				out := modShowResultJSON{
+					Items:   make([]modShowJSON, 0, len(items)),
+					Missing: orEmpty(missing),
+				}
+				for i := range items {
+					out.Items = append(out.Items, newModShowJSON(&items[i]))
+				}
+				return emitJSON(cmd, out)
+			}
+			for i := range items {
+				printModDetails(cmd, &items[i])
+			}
+			if len(missing) > 0 {
+				cmd.Println(styleWarn.Render("could not fetch:"), strings.Join(missing, ", "))
+			}
+			return nil
+		},
+	}
+	cmd.ValidArgsFunction = completeInstalledIDs(st)
+	cmd.Flags().StringP("profile", "p", "", "use a profile's API key")
+	return cmd
+}
+
+func printModDetails(cmd *cobra.Command, it *steam.WorkshopItem) {
+	parsed := it.Parse()
+	kind := "mod"
+	if it.IsCollection() {
+		kind = "collection"
+	}
+	cmd.Printf("%s  %s\n", styleInfo.Render(it.PublishedFileID), it.Title)
+	cmd.Printf("  type: %s   size: %s\n", kind, humanize.Bytes(uint64(it.FileSize)))
+	if len(parsed.Mods) > 0 {
+		cmd.Printf("  mod ids: %s\n", strings.Join(parsed.Mods, ", "))
+	}
+	if len(parsed.Maps) > 0 {
+		cmd.Printf("  maps: %s\n", strings.Join(parsed.Maps, ", "))
+	}
+	if it.IsCollection() && len(it.Children) > 0 {
+		cmd.Printf("  items: %s\n", strings.Join(it.GetChildIDs(), ", "))
+	}
+	if it.ShortDesc != "" {
+		cmd.Printf("  %s\n", styleMuted.Render(it.ShortDesc))
+	}
+	cmd.Println()
+}
+
+// removedFrom returns the entries in before that are absent from after.
+func removedFrom(before, after []string) []string {
+	inAfter := make(map[string]bool, len(after))
+	for _, x := range after {
+		inAfter[x] = true
+	}
+	var out []string
+	for _, x := range before {
+		if !inAfter[x] {
+			out = append(out, x)
+		}
+	}
+	return out
 }

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -101,7 +101,7 @@ func newProfileAddCmd(st *store.Store) *cobra.Command {
 }
 
 func newProfileRemoveCmd(st *store.Store) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "remove <id>",
 		Short: "Remove a profile",
 		Args:  cobra.ExactArgs(1),
@@ -116,10 +116,12 @@ func newProfileRemoveCmd(st *store.Store) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.ValidArgsFunction = completeProfiles(st)
+	return cmd
 }
 
 func newProfileUseCmd(st *store.Store) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "use <id>",
 		Short: "Set the default profile",
 		Args:  cobra.ExactArgs(1),
@@ -134,10 +136,12 @@ func newProfileUseCmd(st *store.Store) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.ValidArgsFunction = completeProfiles(st)
+	return cmd
 }
 
 func newProfileShowCmd(st *store.Store) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "show [id]",
 		Short: "Show profile details",
 		Args:  cobra.MaximumNArgs(1),
@@ -166,6 +170,8 @@ func newProfileShowCmd(st *store.Store) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.ValidArgsFunction = completeProfiles(st)
+	return cmd
 }
 
 func buildBadge(b string) string {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -43,9 +43,11 @@ func NewRootCommand(st *store.Store, ver string) *cobra.Command {
 		newUpdateCmd(),
 		newProfileCmd(st),
 		newValidateCmd(st),
+		newDoctorCmd(st),
 		newSearchCmd(st),
 		newBackupCmd(st),
 		newModsCmd(st),
 	)
+	registerFlagCompletions(root, st)
 	return root
 }

--- a/internal/cli/set.go
+++ b/internal/cli/set.go
@@ -40,10 +40,20 @@ func newSetCmd(st *store.Store) *cobra.Command {
 			if !isAlias && !cfg.Document().Has(key) {
 				return fmt.Errorf("unknown key %q (try `get list`)", args[0])
 			}
+			old := cfg.GetOr(key, "")
 			value := args[1]
 			if tf, ok := setTransforms[args[0]]; ok {
 				value = tf(value)
 			}
+
+			if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
+				if jsonEnabled(cmd) {
+					return emitJSON(cmd, setPreviewJSON{Key: args[0], Old: old, New: value, DryRun: true})
+				}
+				cmd.Printf("%s: %q -> %q (dry run, nothing written)\n", args[0], old, value)
+				return nil
+			}
+
 			cfg.Set(key, value)
 
 			if noSave, _ := cmd.Flags().GetBool("no-save"); noSave {
@@ -63,6 +73,8 @@ func newSetCmd(st *store.Store) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolP("no-save", "n", false, "print the result instead of writing the file")
+	cmd.Flags().Bool("dry-run", false, "show the change without writing")
+	cmd.ValidArgsFunction = completeConfigKeys
 	addTargetFlags(cmd)
 	return cmd
 }


### PR DESCRIPTION
## Summary

Rounds out the scriptable CLI on top of the new `--json` flag so pzmod works
end to end in scripts and CI. All additive and backward compatible.

## What's included

- **`mods show <id...>`**: print resolved Workshop details (title, type, size,
  mod IDs, maps, collection children) as text or `--json`.
- **`--dry-run`** on `set`, `mods add`, `mods remove`: print the change, write
  nothing (no file write, no backup snapshot). Handy with `--json` in CI.
- **`doctor`**: one-shot health check (api-key, config, build, validation) with
  a non-zero exit on error. `--offline` skips the network check.
- **Shell completions**: `--profile` names, installed IDs for `mods remove`/`show`,
  config keys for `get`/`set`. Local only, no network in completion hooks.
